### PR TITLE
使用 UTF-8 编码读取国际化文本资源。

### DIFF
--- a/zeroweb-spring-boot-starter/src/main/java/io/github/xezzon/zeroweb/common/i18n/I18nConfig.java
+++ b/zeroweb-spring-boot-starter/src/main/java/io/github/xezzon/zeroweb/common/i18n/I18nConfig.java
@@ -1,6 +1,6 @@
 package io.github.xezzon.zeroweb.common.i18n;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
@@ -28,7 +28,7 @@ public class I18nConfig {
   public MessageSource messageSource() {
     ResourceBundleMessageSource messageSource = new ResourceBundleMessageSource();
     messageSource.setBasename(BASENAME);
-    messageSource.setDefaultEncoding(Charset.defaultCharset().name());
+    messageSource.setDefaultEncoding(StandardCharsets.UTF_8.name());
     messageSource.setDefaultLocale(Locale.getDefault());
     return messageSource;
   }


### PR DESCRIPTION
<!-- 请先阅览 [开发者指南](https://github.com/xezzon/zeroweb-spring/CONTRIBUTING.md) -->

## Pull Request Checklist

- [x] base分支是 `develop`。
- [x] 选择合适的标签（单选） `feature`/`bug`/`refactor`/`document`。
- [x] 关联 issue。
- [x] 代码经过了格式化。
- [x] 没有引入编译警告。
- [x] 功能已完成。

## Description

## Code Review Checklist

- [ ] 已通过单元测试与 SAST。（由 CI 自动完成）
- [x] 满足需求规格说明书中的功能性需求、非功能性需求。
- [ ] 文档已更新。
  - [ ] 详细设计文档
  - [ ] 代码注释
- [ ] 对外接口保持兼容。
- [ ] 代码风格与现有代码一致。
- [ ] 不存在的安全风险、性能风险。
- [ ] 没有引入不受信任的依赖。
- [ ] Code Review 后，审批或驳回 PR。

## Summary by Sourcery

Bug Fixes:
- Fixed potential encoding issues when reading internationalization text resources by explicitly setting the default encoding to UTF-8.