### PR TITLE
菜单自省

### DIFF
--- a/zeroweb-service/zeroweb-service-admin/src/main/java/io/github/xezzon/zeroweb/common/metadata/MenuService.java
+++ b/zeroweb-service/zeroweb-service-admin/src/main/java/io/github/xezzon/zeroweb/common/metadata/MenuService.java
@@ -1,0 +1,22 @@
+package io.github.xezzon.zeroweb.common.metadata;
+
+import io.github.xezzon.zeroweb.metadata.IMenuService;
+import io.github.xezzon.zeroweb.metadata.MenuInfo;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Stream;
+import org.springframework.stereotype.Service;
+
+@SuppressWarnings("unused")
+@Service
+public class MenuService implements IMenuService {
+
+  @Override
+  public List<MenuInfo> list() {
+    return Stream.of(
+            PermissionConstant.PERMISSIONS
+        )
+        .flatMap(Collection::stream)
+        .toList();
+  }
+}

--- a/zeroweb-service/zeroweb-service-admin/src/main/java/io/github/xezzon/zeroweb/common/metadata/PermissionConstant.java
+++ b/zeroweb-service/zeroweb-service-admin/src/main/java/io/github/xezzon/zeroweb/common/metadata/PermissionConstant.java
@@ -11,7 +11,7 @@ import java.util.List;
 /**
  * 接口权限
  */
-public class PermissionConstant {
+public final class PermissionConstant {
 
   static final List<MenuInfo> PERMISSIONS;
 
@@ -20,13 +20,13 @@ public class PermissionConstant {
         .filter(field -> Modifier.isStatic(field.getModifiers()))
         .filter(field -> Modifier.isPublic(field.getModifiers()))
         .map(field -> {
-          String value;
+          final String value;
           try {
             value = field.get(null).toString();
           } catch (IllegalAccessException e) {
             throw new ZerowebRuntimeException(e);
           }
-          MenuInfo resourceInfo = new MenuInfo();
+          final MenuInfo resourceInfo = new MenuInfo();
           resourceInfo.setType(MenuType.PERMISSION);
           resourceInfo.setPath(value);
           resourceInfo.setPermissions(Collections.singleton(value));

--- a/zeroweb-service/zeroweb-service-admin/src/main/java/io/github/xezzon/zeroweb/common/metadata/PermissionConstant.java
+++ b/zeroweb-service/zeroweb-service-admin/src/main/java/io/github/xezzon/zeroweb/common/metadata/PermissionConstant.java
@@ -1,0 +1,40 @@
+package io.github.xezzon.zeroweb.common.metadata;
+
+import io.github.xezzon.zeroweb.common.exception.ZerowebRuntimeException;
+import io.github.xezzon.zeroweb.metadata.MenuInfo;
+import io.github.xezzon.zeroweb.metadata.MenuType;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 接口权限
+ */
+public class PermissionConstant {
+
+  static final List<MenuInfo> PERMISSIONS;
+
+  static {
+    PERMISSIONS = Arrays.stream(PermissionConstant.class.getDeclaredFields())
+        .filter(field -> Modifier.isStatic(field.getModifiers()))
+        .filter(field -> Modifier.isPublic(field.getModifiers()))
+        .map(field -> {
+          String value;
+          try {
+            value = field.get(null).toString();
+          } catch (IllegalAccessException e) {
+            throw new ZerowebRuntimeException(e);
+          }
+          MenuInfo resourceInfo = new MenuInfo();
+          resourceInfo.setType(MenuType.PERMISSION);
+          resourceInfo.setPath(value);
+          resourceInfo.setPermissions(Collections.singleton(value));
+          return resourceInfo;
+        })
+        .toList();
+  }
+
+  private PermissionConstant() {
+  }
+}

--- a/zeroweb-spring-boot-starter/src/main/java/io/github/xezzon/zeroweb/metadata/DefaultMenuService.java
+++ b/zeroweb-spring-boot-starter/src/main/java/io/github/xezzon/zeroweb/metadata/DefaultMenuService.java
@@ -1,0 +1,17 @@
+package io.github.xezzon.zeroweb.metadata;
+
+import java.util.Collections;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author xezzon
+ */
+@Service
+public class DefaultMenuService implements IMenuService {
+
+  @Override
+  public List<MenuInfo> list() {
+    return Collections.emptyList();
+  }
+}

--- a/zeroweb-spring-boot-starter/src/main/java/io/github/xezzon/zeroweb/metadata/IMenuService.java
+++ b/zeroweb-spring-boot-starter/src/main/java/io/github/xezzon/zeroweb/metadata/IMenuService.java
@@ -1,0 +1,15 @@
+package io.github.xezzon.zeroweb.metadata;
+
+import java.util.List;
+
+/**
+ * 权限服务
+ */
+public interface IMenuService {
+
+  /**
+   * 列举服务内所有的接口权限与资源权限
+   * @return 权限列表
+   */
+  List<MenuInfo> list();
+}

--- a/zeroweb-spring-boot-starter/src/main/java/io/github/xezzon/zeroweb/metadata/MenuInfo.java
+++ b/zeroweb-spring-boot-starter/src/main/java/io/github/xezzon/zeroweb/metadata/MenuInfo.java
@@ -1,0 +1,29 @@
+package io.github.xezzon.zeroweb.metadata;
+
+import java.util.Collection;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * 资源信息
+ */
+@Getter
+@Setter
+@ToString
+public class MenuInfo {
+
+  /**
+   * 资源类型
+   */
+  private MenuType type;
+  /**
+   * 资源路径 不同类型的资源有不同的路径格式
+   * @see MenuType
+   */
+  private String path;
+  /**
+   * 访问资源所需要的权限 取并集，即资源必须满足所列出的所有权限
+   */
+  private Collection<String> permissions;
+}

--- a/zeroweb-spring-boot-starter/src/main/java/io/github/xezzon/zeroweb/metadata/MenuType.java
+++ b/zeroweb-spring-boot-starter/src/main/java/io/github/xezzon/zeroweb/metadata/MenuType.java
@@ -1,0 +1,28 @@
+package io.github.xezzon.zeroweb.metadata;
+
+/**
+ * 菜单类型
+ */
+public enum MenuType {
+
+  /**
+   * 路由 路径格式为 `/menu/submenu`
+   */
+  ROUTE,
+  /**
+   * 外部链接。点击后会打开一个新的标签页 路径格式为 `https://domain.com/path`
+   */
+  EXTERNAL_LINK,
+  /**
+   * 嵌入页面。会在当前页面嵌入一个外部网页。 路径格式为 `https://domain.com/path`
+   */
+  EMBEDDED,
+  /**
+   * 接口权限 路径格式为 `resource:operation`，operation 通常为 `read`（可省略）、`write` 等。
+   */
+  PERMISSION,
+  /**
+   * 资源权限 路径格式为 `resource:#:operation`，operation 通常为 `read`（可省略）、`write` 等。
+   */
+  GROUP_PERMISSION,
+}

--- a/zeroweb-spring-boot-starter/src/main/java/io/github/xezzon/zeroweb/metadata/MetadataController.java
+++ b/zeroweb-spring-boot-starter/src/main/java/io/github/xezzon/zeroweb/metadata/MetadataController.java
@@ -1,5 +1,8 @@
 package io.github.xezzon.zeroweb.metadata;
 
+import jakarta.annotation.Resource;
+import java.util.Collection;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,6 +20,8 @@ public class MetadataController {
   private String appName;
   @Value("${spring.application.version}")
   private String appVersion;
+  @Resource
+  private List<IMenuService> resourceServices;
 
   /**
    * 服务自省服务信息
@@ -30,5 +35,17 @@ public class MetadataController {
     serviceInfo.setType(ServiceType.SERVER);
     serviceInfo.setHidden(true);
     return serviceInfo;
+  }
+
+  /**
+   * 服务自省资源信息
+   * @return 资源信息
+   */
+  @GetMapping("/menu.json")
+  public List<MenuInfo> loadResourceInfo() {
+    return resourceServices.stream()
+        .map(IMenuService::list)
+        .flatMap(Collection::stream)
+        .toList();
   }
 }

--- a/zeroweb-spring-boot-starter/src/test/java/io/github/xezzon/zeroweb/metadata/MenuService.java
+++ b/zeroweb-spring-boot-starter/src/test/java/io/github/xezzon/zeroweb/metadata/MenuService.java
@@ -1,0 +1,48 @@
+package io.github.xezzon.zeroweb.metadata;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author xezzon
+ */
+@Service
+public class MenuService implements IMenuService {
+
+  public static final List<MenuInfo> MENU_INFOS = new ArrayList<>();
+
+  static {
+    final MenuInfo route = new MenuInfo();
+    route.setType(MenuType.ROUTE);
+    route.setPath("/article/[articleId]");
+    route.setPermissions(List.of("article:write", "article:read"));
+    MENU_INFOS.add(route);
+    final MenuInfo externalLink = new MenuInfo();
+    externalLink.setType(MenuType.EXTERNAL_LINK);
+    externalLink.setPath("https://cloudflare.com");
+    externalLink.setPermissions(Collections.emptyList());
+    MENU_INFOS.add(externalLink);
+    final MenuInfo embedded = new MenuInfo();
+    embedded.setType(MenuType.EMBEDDED);
+    embedded.setPath("https://github.com");
+    embedded.setPermissions(Collections.singletonList("github"));
+    MENU_INFOS.add(embedded);
+    final MenuInfo permission = new MenuInfo();
+    permission.setType(MenuType.PERMISSION);
+    permission.setPath("article:write");
+    permission.setPermissions(Collections.singletonList("article:write"));
+    MENU_INFOS.add(permission);
+    final MenuInfo groupPermission = new MenuInfo();
+    groupPermission.setType(MenuType.GROUP_PERMISSION);
+    groupPermission.setPath("subscription:#:create");
+    groupPermission.setPermissions(Collections.singletonList("subscription:#:create"));
+    MENU_INFOS.add(groupPermission);
+  }
+
+  @Override
+  public List<MenuInfo> list() {
+    return MENU_INFOS;
+  }
+}

--- a/zeroweb-spring-boot-starter/src/test/java/io/github/xezzon/zeroweb/metadata/MetadataHttpTest.java
+++ b/zeroweb-spring-boot-starter/src/test/java/io/github/xezzon/zeroweb/metadata/MetadataHttpTest.java
@@ -4,6 +4,7 @@ import static com.google.auth.http.AuthHttpConstants.AUTHORIZATION;
 
 import io.github.xezzon.zeroweb.auth.TestJwtGenerator;
 import jakarta.annotation.Resource;
+import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -34,5 +35,26 @@ class MetadataHttpTest {
     Assertions.assertEquals("1.0.0", responseBody.getVersion());
     Assertions.assertEquals(ServiceType.SERVER, responseBody.getType());
     Assertions.assertTrue(responseBody.isHidden());
+  }
+
+  @Test
+  void resourceInfo() {
+    List<MenuInfo> responseBody = webTestClient.get()
+        .uri("/metadata/menu.json")
+        .exchange()
+        .expectBodyList(MenuInfo.class)
+        .returnResult().getResponseBody();
+    Assertions.assertNotNull(responseBody);
+    Assertions.assertEquals(MenuService.MENU_INFOS.size(), responseBody.size());
+    for (int i = 0, cnt = MenuService.MENU_INFOS.size(); i < cnt; i++) {
+      MenuInfo except = MenuService.MENU_INFOS.get(i);
+      MenuInfo actual = responseBody.get(i);
+      Assertions.assertEquals(except.getType(), actual.getType());
+      Assertions.assertEquals(except.getPath(), actual.getPath());
+      Assertions.assertEquals(
+          String.join(",", except.getPermissions()),
+          String.join(",", actual.getPermissions())
+      );
+    }
   }
 }


### PR DESCRIPTION
<!-- 请先阅览 [开发者指南](https://github.com/xezzon/zeroweb-spring/CONTRIBUTING.md) -->

## Pull Request Checklist

- [x] base分支是 `develop`。
- [x] 选择合适的标签（单选） `feature`/`bug`/`refactor`/`document`。
- [x] 关联 issue。
- [x] 代码经过了格式化。
- [x] 没有引入编译警告。
- [x] 功能已完成。

## Description

## Code Review Checklist

- [ ] 已通过单元测试与 SAST。（由 CI 自动完成）
- [ ] 满足需求规格说明书中的功能性需求、非功能性需求。
- [ ] 文档已更新。
  - [ ] 详细设计文档
  - [ ] 代码注释
- [ ] 对外接口保持兼容。
- [ ] 代码风格与现有代码一致。
- [ ] 不存在的安全风险、性能风险。
- [ ] 没有引入不受信任的依赖。
- [ ] Code Review 后，审批或驳回 PR。

## Summary by Sourcery

Implement a menu and permission self-inspection mechanism for the application, allowing dynamic retrieval of menu and permission metadata

New Features:
- Add a mechanism to list and expose menu and permission information via a metadata endpoint
- Introduce MenuInfo and MenuType to represent different types of menu and permission resources

Enhancements:
- Create an extensible interface for menu and permission metadata retrieval
- Implement different menu service strategies for test and production environments

Tests:
- Add test cases to verify menu metadata retrieval
- Create a test MenuService with predefined menu information