### PR TITLE
fix: /auth/self 端点未认证的情况下会返回 401 状态。

### DIFF
--- a/zeroweb-service/zeroweb-service-admin/src/main/java/io/github/xezzon/zeroweb/auth/internal/AuthnHttpEndpoint.java
+++ b/zeroweb-service/zeroweb-service-admin/src/main/java/io/github/xezzon/zeroweb/auth/internal/AuthnHttpEndpoint.java
@@ -63,7 +63,6 @@ public class AuthnHttpEndpoint {
   /**
    * @return 当前用户的认证信息
    */
-  @SaCheckLogin
   @GetMapping("/self")
   public ResponseEntity<byte[]> self() throws InvalidProtocolBufferException {
     if (!StpUtil.isLogin()) {
@@ -91,9 +90,6 @@ public class AuthnHttpEndpoint {
   @SaCheckLogin
   @GetMapping("/token")
   public OidcToken getSsoToken(HttpServletResponse response) {
-    if (!StpUtil.isLogin()) {
-      return null;
-    }
     final String accessToken = StpUtil.getTokenValue();
     final String idToken = authnService.signJwt();
     final Long expiredIn = zerowebJwtConfig.getTimeout();

--- a/zeroweb-service/zeroweb-service-admin/src/test/java/io/github/xezzon/zeroweb/auth/AuthnHttpTest.java
+++ b/zeroweb-service/zeroweb-service-admin/src/test/java/io/github/xezzon/zeroweb/auth/AuthnHttpTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -250,5 +251,13 @@ class AuthnHttpTest {
           DecodedJWT actual = verifier.verify(jwt);
           assertEquals(excepted.getSubject(), actual.getSubject());
         });
+  }
+
+  @Test
+  void forwardAuth_notLogin() {
+    webTestClient.get()
+        .uri("/auth/self")
+        .exchange()
+        .expectStatus().isEqualTo(HttpStatus.NO_CONTENT);
   }
 }


### PR DESCRIPTION
<!-- 请先阅览 [开发者指南](https://github.com/xezzon/zeroweb-spring/CONTRIBUTING.md) -->

## Pull Request Checklist

- [ ] base分支是 `develop`。
- [ ] 选择合适的标签（单选） `feature`/`bug`/`refactor`/`document`。
- [ ] 关联 issue。
- [ ] 代码经过了格式化。
- [ ] 没有引入编译警告。
- [ ] 功能已完成。

## Description

## Code Review Checklist

- [ ] 已通过单元测试与 SAST。（由 CI 自动完成）
- [ ] 满足需求规格说明书中的功能性需求、非功能性需求。
- [ ] 文档已更新。
  - [ ] 详细设计文档
  - [ ] 代码注释
- [ ] 对外接口保持兼容。
- [ ] 代码风格与现有代码一致。
- [ ] 不存在的安全风险、性能风险。
- [ ] 没有引入不受信任的依赖。
- [ ] Code Review 后，审批或驳回 PR。

## Summary by Sourcery

Revise authentication endpoints to return appropriate status for unauthenticated users and clean up redundant login checks

Bug Fixes:
- Ensure GET /auth/self returns 204 No Content instead of 401 when not authenticated

Enhancements:
- Remove @SaCheckLogin from /auth/self to allow custom unauthenticated handling
- Eliminate redundant login guard in the /auth/token endpoint

Tests:
- Add test for unauthenticated /auth/self endpoint expecting HttpStatus.NO_CONTENT