### PR TITLE
修改 Redis 序列化方法为 Gson。

### DIFF
--- a/zeroweb-spring-boot-starter/pom.xml
+++ b/zeroweb-spring-boot-starter/pom.xml
@@ -52,11 +52,7 @@
     <dependency>
       <groupId>org.springframework.grpc</groupId>
       <artifactId>spring-grpc-test</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <optional>true</optional>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -71,7 +67,10 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-redis</artifactId>
-      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/zeroweb-spring-boot-starter/src/main/java/io/github/xezzon/zeroweb/common/redis/GsonRedisSerializer.java
+++ b/zeroweb-spring-boot-starter/src/main/java/io/github/xezzon/zeroweb/common/redis/GsonRedisSerializer.java
@@ -1,0 +1,31 @@
+package io.github.xezzon.zeroweb.common.redis;
+
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.SerializationException;
+
+/**
+ * @author xezzon
+ */
+public class GsonRedisSerializer<T> implements RedisSerializer<T> {
+
+  private static final Gson GSON = new Gson();
+  private final Type type;
+
+  public GsonRedisSerializer(final TypeToken<T> typeToken) {
+    this.type = typeToken.getType();
+  }
+
+  @Override
+  public byte[] serialize(final T value) throws SerializationException {
+    return GSON.toJson(value).getBytes(StandardCharsets.UTF_8);
+  }
+
+  @Override
+  public T deserialize(final byte[] bytes) throws SerializationException {
+    return GSON.fromJson(new String(bytes, StandardCharsets.UTF_8), type);
+  }
+}

--- a/zeroweb-spring-boot-starter/src/main/java/io/github/xezzon/zeroweb/common/redis/RedisTemplateFactory.java
+++ b/zeroweb-spring-boot-starter/src/main/java/io/github/xezzon/zeroweb/common/redis/RedisTemplateFactory.java
@@ -1,13 +1,10 @@
 package io.github.xezzon.zeroweb.common.redis;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.springframework.context.annotation.Bean;
+import com.google.common.reflect.TypeToken;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
-import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -20,12 +17,10 @@ public class RedisTemplateFactory {
 
   private final RedisConnectionFactory connectionFactory;
   private final RedisSerializer<String> keySerializer;
-  private final ObjectMapper objectMapper;
 
-  public RedisTemplateFactory(RedisConnectionFactory connectionFactory, ObjectMapper objectMapper) {
+  public RedisTemplateFactory(final RedisConnectionFactory connectionFactory) {
     this.connectionFactory = connectionFactory;
     this.keySerializer = new StringRedisSerializer();
-    this.objectMapper = objectMapper;
   }
 
   /**
@@ -34,33 +29,17 @@ public class RedisTemplateFactory {
    * public class AnyService {
    *   private final RedisTemplate&lt;String, Any&gt; anyRedisTemplate;
    *   public AnyService(RedisTemplateFactory factory) {
-   *     this.anyRedisTemplate = factory.of(Any.class)
+   *     this.anyRedisTemplate = factory.of(new TypeToken&lt;&gt;() {});
    *   }
    * }
    * </pre>
    */
-  public <T> RedisTemplate<String, T> of(Class<T> tClass) {
+  public <T> RedisTemplate<String, T> of(final TypeToken<T> typeToken) {
     RedisTemplate<String, T> redisTemplate = new RedisTemplate<>();
     redisTemplate.setConnectionFactory(connectionFactory);
     redisTemplate.setKeySerializer(keySerializer);
     redisTemplate.setHashKeySerializer(keySerializer);
-    RedisSerializer<T> valueSerializer = new Jackson2JsonRedisSerializer<>(objectMapper, tClass);
-    redisTemplate.setValueSerializer(valueSerializer);
-    redisTemplate.setHashValueSerializer(valueSerializer);
-    redisTemplate.afterPropertiesSet();
-    return redisTemplate;
-  }
-
-  /**
-   * 常规 Redis 处理器
-   */
-  @Bean
-  <T> RedisTemplate<String, T> genericRedisTemplate() {
-    RedisTemplate<String, T> redisTemplate = new RedisTemplate<>();
-    redisTemplate.setConnectionFactory(connectionFactory);
-    redisTemplate.setKeySerializer(keySerializer);
-    redisTemplate.setKeySerializer(keySerializer);
-    RedisSerializer<?> valueSerializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+    final RedisSerializer<T> valueSerializer = new GsonRedisSerializer<>(typeToken);
     redisTemplate.setValueSerializer(valueSerializer);
     redisTemplate.setHashValueSerializer(valueSerializer);
     redisTemplate.afterPropertiesSet();

--- a/zeroweb-spring-boot-starter/src/test/java/io/github/xezzon/zeroweb/common/jpa/TestEntity.java
+++ b/zeroweb-spring-boot-starter/src/test/java/io/github/xezzon/zeroweb/common/jpa/TestEntity.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.util.Objects;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -27,4 +28,17 @@ public class TestEntity implements IEntity<String> {
   private String field1;
   @Column(name = "field2")
   private String field2;
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof TestEntity that)) {
+      return false;
+    }
+    return Objects.equals(id, that.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(id);
+  }
 }

--- a/zeroweb-spring-boot-starter/src/test/java/io/github/xezzon/zeroweb/common/redis/ChildEntity.java
+++ b/zeroweb-spring-boot-starter/src/test/java/io/github/xezzon/zeroweb/common/redis/ChildEntity.java
@@ -1,0 +1,17 @@
+package io.github.xezzon.zeroweb.common.redis;
+
+import io.github.xezzon.zeroweb.common.jpa.TestEntity;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * @author xezzon
+ */
+@Getter
+@Setter
+@ToString
+public class ChildEntity extends TestEntity {
+
+  private String field3;
+}

--- a/zeroweb-spring-boot-starter/src/test/java/io/github/xezzon/zeroweb/common/redis/RedisTemplateFactoryTest.java
+++ b/zeroweb-spring-boot-starter/src/test/java/io/github/xezzon/zeroweb/common/redis/RedisTemplateFactoryTest.java
@@ -1,14 +1,21 @@
 package io.github.xezzon.zeroweb.common.redis;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
+import cn.hutool.core.util.RandomUtil;
+import com.google.common.reflect.TypeToken;
 import io.github.xezzon.zeroweb.common.jpa.TestEntity;
 import jakarta.annotation.Resource;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
 
 /**
  * @author xezzon
@@ -18,18 +25,43 @@ import org.springframework.test.context.ActiveProfiles;
 @DirtiesContext
 class RedisTemplateFactoryTest {
 
+  private static final String CACHE_KEY = "testEntity";
   @Resource
   private RedisTemplateFactory factory;
+  private static final GenericContainer<?> REDIS_CONTAINER =
+      new GenericContainer<>("redis:7-alpine");
 
-  @Test
-  void of() {
-    RedisTemplate<String, TestEntity> redisTemplate = factory.of(TestEntity.class);
-    assertNotNull(redisTemplate);
+  @BeforeAll
+  static void beforeAll() {
+    REDIS_CONTAINER
+        .withExposedPorts(6379)
+        .start();
+  }
+
+  @DynamicPropertySource
+  @SuppressWarnings("unused")
+  static void redisProperties(DynamicPropertyRegistry registry) {
+    registry.add("REDIS_URL", () -> String.format(
+        "%s:%s", REDIS_CONTAINER.getHost(), REDIS_CONTAINER.getMappedPort(6379)
+    ));
   }
 
   @Test
-  void genericRedisTemplate() {
-    RedisTemplate<String, TestEntity> redisTemplate = factory.genericRedisTemplate();
-    assertNotNull(redisTemplate);
+  void of() {
+    List<TestEntity> excepts = new LinkedList<>();
+    for (int i = 0, cnt = 8; i < cnt; i++) {
+      TestEntity testEntity = new TestEntity();
+      testEntity.setId(UUID.randomUUID().toString());
+      testEntity.setField1(RandomUtil.randomString(8));
+      testEntity.setField2(RandomUtil.randomString(6));
+      excepts.add(testEntity);
+    }
+    factory.of(new TypeToken<>() {})
+        .opsForValue()
+        .set(CACHE_KEY, excepts);
+    List<ChildEntity> actual = factory.<List<ChildEntity>>of(new TypeToken<>() {})
+        .opsForValue()
+        .get(CACHE_KEY);
+    Assertions.assertIterableEquals(excepts, actual);
   }
 }


### PR DESCRIPTION
<!-- 请先阅览 [开发者指南](https://github.com/xezzon/zeroweb-spring/CONTRIBUTING.md) -->

## Pull Request Checklist

- [ ] base分支是 `develop`。
- [ ] 选择合适的标签（单选） `feature`/`bug`/`refactor`/`document`。
- [ ] 关联 issue。
- [ ] 代码经过了格式化。
- [ ] 没有引入编译警告。
- [ ] 功能已完成。

## Description

## Code Review Checklist

- [ ] 已通过单元测试与 SAST。（由 CI 自动完成）
- [ ] 满足需求规格说明书中的功能性需求、非功能性需求。
- [ ] 文档已更新。
  - [ ] 详细设计文档
  - [ ] 代码注释
- [ ] 对外接口保持兼容。
- [ ] 代码风格与现有代码一致。
- [ ] 不存在的安全风险、性能风险。
- [ ] 没有引入不受信任的依赖。
- [ ] Code Review 后，审批或驳回 PR。

## Summary by Sourcery

Switch Redis serialization from Jackson to a custom Gson-based approach with generic type support, update the RedisTemplateFactory API and propagate changes to tests and dependencies.

Enhancements:
- Replace Jackson-based Redis serializers with a custom GsonRedisSerializer leveraging TypeToken for generic handling
- Change RedisTemplateFactory.of to accept TypeToken<T> instead of Class<T> and remove the unused genericRedisTemplate bean and ObjectMapper injection

Build:
- Remove Jackson Databind as an optional dependency and add Gson dependency in the Redis starter POM

Tests:
- Integrate Testcontainers for Redis in tests with dynamic properties and update RedisTemplateFactoryTest to validate generic serialization round-trip
- Add equals/hashCode to TestEntity and introduce ChildEntity to support list comparison in tests