### PR TITLE
refactor(test): 将 LocalStack 切换为 Floci

### DIFF
--- a/zeroweb-service/zeroweb-service-file/pom.xml
+++ b/zeroweb-service/zeroweb-service-file/pom.xml
@@ -23,6 +23,7 @@
     <spring-boot.run.main-class>
       io.github.xezzon.zeroweb.ZerowebFileApplication
     </spring-boot.run.main-class>
+    <testcontainers-floci.version>2.11.0</testcontainers-floci.version>
   </properties>
 
   <dependencyManagement>
@@ -52,8 +53,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>testcontainers-localstack</artifactId>
+      <groupId>io.floci</groupId>
+      <artifactId>testcontainers-floci</artifactId>
+      <version>${testcontainers-floci.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/zeroweb-service/zeroweb-service-file/src/test/java/io/github/xezzon/zeroweb/attachment/AttachmentGrpcTest.java
+++ b/zeroweb-service/zeroweb-service-file/src/test/java/io/github/xezzon/zeroweb/attachment/AttachmentGrpcTest.java
@@ -3,6 +3,7 @@ package io.github.xezzon.zeroweb.attachment;
 import cn.hutool.core.util.RandomUtil;
 import com.google.common.hash.Hashing;
 import com.google.protobuf.ByteString;
+import io.floci.testcontainers.FlociContainer;
 import io.github.xezzon.zeroweb.attachment.AttachmentServiceGrpc.AttachmentServiceBlockingStub;
 import io.github.xezzon.zeroweb.attachment.AttachmentServiceGrpc.AttachmentServiceStub;
 import io.github.xezzon.zeroweb.attachment.enumeration.AttachmentStatusEnum;
@@ -16,6 +17,7 @@ import jakarta.annotation.Resource;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Base64;
@@ -36,14 +38,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.localstack.LocalStackContainer;
-import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 
 @SpringBootTest
@@ -284,9 +283,7 @@ abstract class AttachmentGrpcTest {
 @Slf4j
 class S3GrpcTest extends AttachmentGrpcTest {
 
-  private static final LocalStackContainer CONTAINER = new LocalStackContainer(
-      DockerImageName.parse("localstack/localstack:s3-community-archive")
-  ).withServices("s3");
+  private static final FlociContainer CONTAINER = new FlociContainer();
   private static final String BUCKET = "test";
   private static S3Client s3Client = null;
 
@@ -294,15 +291,12 @@ class S3GrpcTest extends AttachmentGrpcTest {
   static void beforeAll() {
     CONTAINER.start();
     s3Client = S3Client.builder()
-        .endpointOverride(CONTAINER.getEndpoint())
+        .endpointOverride(URI.create(CONTAINER.getEndpoint()))
+        .region(Region.of(CONTAINER.getRegion()))
         .credentialsProvider(StaticCredentialsProvider.create(
             AwsBasicCredentials.create(CONTAINER.getAccessKey(), CONTAINER.getSecretKey())
         ))
-        .region(Region.US_EAST_1)
-        .serviceConfiguration(S3Configuration.builder()
-            .pathStyleAccessEnabled(true)
-            .build()
-        )
+        .forcePathStyle(true)
         .build();
     s3Client.createBucket(builder -> builder.bucket(BUCKET));
   }

--- a/zeroweb-service/zeroweb-service-file/src/test/java/io/github/xezzon/zeroweb/attachment/AttachmentHttpTest.java
+++ b/zeroweb-service/zeroweb-service-file/src/test/java/io/github/xezzon/zeroweb/attachment/AttachmentHttpTest.java
@@ -8,6 +8,7 @@ import cn.hutool.core.util.HexUtil;
 import cn.hutool.core.util.RandomUtil;
 import com.google.common.hash.Hashing;
 import com.google.common.io.ByteSource;
+import io.floci.testcontainers.FlociContainer;
 import io.github.xezzon.zeroweb.attachment.entity.AddAttachmentReq;
 import io.github.xezzon.zeroweb.attachment.entity.UploadInfo;
 import io.github.xezzon.zeroweb.attachment.enumeration.AttachmentStatusEnum;
@@ -54,14 +55,11 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.servlet.client.RestTestClient;
-import org.testcontainers.localstack.LocalStackContainer;
-import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 
@@ -898,9 +896,7 @@ abstract class AttachmentHttpTest {
 @ActiveProfiles("s3")
 class S3HttpTest extends AttachmentHttpTest {
 
-  private static final LocalStackContainer CONTAINER = new LocalStackContainer(
-      DockerImageName.parse("localstack/localstack:s3-community-archive")
-  ).withServices("s3");
+  private static final FlociContainer CONTAINER = new FlociContainer();
   private static final String BUCKET = "test";
   private static S3Client s3Client = null;
   @Resource
@@ -912,15 +908,12 @@ class S3HttpTest extends AttachmentHttpTest {
   static void beforeAll() {
     CONTAINER.start();
     s3Client = S3Client.builder()
-        .endpointOverride(CONTAINER.getEndpoint())
+        .endpointOverride(URI.create(CONTAINER.getEndpoint()))
         .credentialsProvider(StaticCredentialsProvider.create(
             AwsBasicCredentials.create(CONTAINER.getAccessKey(), CONTAINER.getSecretKey())
         ))
         .region(Region.US_EAST_1)
-        .serviceConfiguration(S3Configuration.builder()
-            .pathStyleAccessEnabled(true)
-            .build()
-        )
+        .forcePathStyle(true)
         .build();
     s3Client.createBucket(builder -> builder.bucket(BUCKET));
   }

--- a/zeroweb-service/zeroweb-service-file/src/test/java/io/github/xezzon/zeroweb/storage/s3/S3ServiceTest.java
+++ b/zeroweb-service/zeroweb-service-file/src/test/java/io/github/xezzon/zeroweb/storage/s3/S3ServiceTest.java
@@ -2,6 +2,7 @@ package io.github.xezzon.zeroweb.storage.s3;
 
 import cn.hutool.core.util.HexUtil;
 import cn.hutool.core.util.RandomUtil;
+import io.floci.testcontainers.FlociContainer;
 import io.github.xezzon.zeroweb.attachment.Attachment;
 import io.github.xezzon.zeroweb.attachment.enumeration.AttachmentStatusEnum;
 import io.github.xezzon.zeroweb.attachment.repository.AttachmentRepository;
@@ -30,14 +31,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.localstack.LocalStackContainer;
 import org.testcontainers.shaded.com.google.common.hash.Hashing;
-import org.testcontainers.utility.DockerImageName;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
@@ -49,9 +47,7 @@ import software.amazon.awssdk.services.s3.model.MultipartUpload;
 @SpringBootTest
 class S3ServiceTest {
 
-  private static final LocalStackContainer CONTAINER = new LocalStackContainer(
-      DockerImageName.parse("localstack/localstack:s3-community-archive")
-  );
+  private static final FlociContainer CONTAINER = new FlociContainer();
   private static final String BUCKET = "test";
   private static final String FILE_NAME = "test.txt";
   private static final String LARGE_FILE_NAME = "large_file.jpg";
@@ -69,15 +65,12 @@ class S3ServiceTest {
   static void beforeAll() {
     CONTAINER.start();
     s3Client = S3Client.builder()
-        .endpointOverride(CONTAINER.getEndpoint())
+        .endpointOverride(URI.create(CONTAINER.getEndpoint()))
         .credentialsProvider(StaticCredentialsProvider.create(
             AwsBasicCredentials.create(CONTAINER.getAccessKey(), CONTAINER.getSecretKey())
         ))
         .region(Region.US_EAST_1)
-        .serviceConfiguration(S3Configuration.builder()
-            .pathStyleAccessEnabled(true)
-            .build()
-        )
+        .forcePathStyle(true)
         .build();
     s3Client.createBucket(builder -> builder.bucket(BUCKET));
   }


### PR DESCRIPTION
## Pull Request Checklist

- [x] base分支是 `develop`。（仓库实际默认基线为 `main`）
- [x] 选择合适的标签（单选） `feature`/`bug`/`refactor`/`document`：`refactor`。
- [ ] 关联 issue。（未检索到对应 issue）
- [x] 代码经过了格式化。
- [x] 没有引入编译警告。
- [x] 功能已完成。

## Description

将 `zeroweb-service-file` 模块测试中基于 `testcontainers/localstack` 的 `LocalStackContainer`，替换为 `io.floci:testcontainers` 提供的 `FlociContainer`。

主要变更：
- 删除 `org.testcontainers:localstack` 相关依赖，引入 Floci testcontainers 依赖。
- `AttachmentHttpTest` / `AttachmentGrpcTest` / `S3ServiceTest` 改用 `FlociContainer` 启动本地 S3 服务。
- 使用 S3 SDK 的 `forcePathStyle(true)` 替代原先的 `S3Configuration.pathStyleAccessEnabled(true)`，简化客户端配置。

关联文件：
- `zeroweb-service/zeroweb-service-file/pom.xml`
- `zeroweb-service/zeroweb-service-file/src/test/java/io/github/xezzon/zeroweb/attachment/AttachmentHttpTest.java`
- `zeroweb-service/zeroweb-service-file/src/test/java/io/github/xezzon/zeroweb/attachment/AttachmentGrpcTest.java`
- `zeroweb-service/zeroweb-service-file/src/test/java/io/github/xezzon/zeroweb/storage/s3/S3ServiceTest.java`

## Code Review Checklist

- [ ] 已通过单元测试与 SAST。（由 CI 自动完成）
- [ ] 满足需求规格说明书中的功能性需求、非功能性需求。
- [ ] 文档已更新。
  - [ ] 详细设计文档
  - [ ] 代码注释
- [x] 对外接口保持兼容。（仅测试容器替换，不涉及对外接口）
- [x] 代码风格与现有代码一致。
- [x] 不存在的安全风险、性能风险。
- [ ] 没有引入不受信任的依赖。
- [ ] Code Review 后，审批或驳回 PR。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated S3 attachment and storage integration tests to use the new local cloud-service emulator.
  * Improved endpoint and region configuration for S3 test scenarios.
  * Preserved path-style S3 access across HTTP, gRPC, and storage tests.
* **Chores**
  * Replaced the previous local AWS service testing dependency with the new emulator dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->